### PR TITLE
Landing page

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,8 @@
+import '@/styles/globals.css'
+import type { AppProps } from 'next/app'
+ 
+const App = ({ Component, pageProps }: AppProps) => {
+  return <Component {...pageProps} />
+}
+
+export default App

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,8 +1,8 @@
 import { PackageManager } from '@components/typewriter'
 
 <div className="h-full flex items-center justify-center">
-    <div>
-    <h1 className='text-4xl font-bold'>Thread - v0.1.3</h1>
-    <div className="text-center"><PackageManager /></div>
+    <div className="mb-16">
+        <h1 className='text-4xl font-bold'>Thread - v0.1.3</h1>
+        <div className="text-center"><PackageManager /></div>
     </div>
 </div>

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,9 +1,8 @@
----
-Thread
----
-
-<h1>Thread - v0.1.3</h1>
-
 import { PackageManager } from '@components/typewriter'
 
-<PackageManager />
+<div className="h-full flex items-center justify-center">
+    <div>
+    <h1 className='text-4xl font-bold'>Thread - v0.1.3</h1>
+    <div className="text-center"><PackageManager /></div>
+    </div>
+</div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,8 +19,3 @@
     --accent: #3F01BC;
   }
 }
-
-body {
-  background: var(--background);
-  background: linear-gradient(225deg, var(--background) 80%, var(--primary) 100%);
-}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,5 +15,6 @@ const config: Config = {
     },
   },
   plugins: [],
+  darkMode: 'class'
 }
 export default config


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Breaking Change
- [ ] Documentation Update

## Description
**TLDR: Quickly made landing page**

This is what the landing page looks like:
![Light Theme](https://github.com/python-thread/thread.ngjx.org/assets/44159210/14725f4f-eb61-42a6-be3c-88904e8bd6b0)
![Dark Theme](https://github.com/python-thread/thread.ngjx.org/assets/44159210/058ab29f-f906-4fdb-93dc-388c91edacef)

I have quickly just made the front landing page so that it looks all nice. This is in accordance with what was discussed over discord. It is a shame that I couldn't seem to get the styling working correctly. Hopefully in the future we will have something more substantial :)

I have refactored the landing page to this.
```html
<div className="h-full flex items-center justify-center">
    <div className="mb-16">
        <h1 className='text-4xl font-bold'>Thread - v0.1.3</h1>
        <div className="text-center"><PackageManager /></div>
    </div>
</div>
```
I offset the content of the landing page by adding `mb-16` which is the size of the navigation bar. That way it is flush with the center of the screen. It also seems to be alright on mobile devices as well. Here is what the landing page looks like on the Galaxy Note 20:

> [!NOTE]  
> The image is broken when put into markdown so here is the link haha.
> https://github.com/python-thread/thread.ngjx.org/assets/44159210/a13c307a-606c-450e-a39c-e5ff7a75a0bb

---

I have removed the CSS styling as it doesn't work as intended for the time being. This is the code that was removed:
```css
body {
  background: var(--background);
  background: linear-gradient(225deg, var(--background) 80%, var(--primary) 100%);
}
```

---

I have also changed the tailwind config file to allow support for dark mode. I don't use it, but I don't see the harm in adding it in for the moment.
```
darkMode: 'class'
```

## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #9

## QA Instructions, Screenshots, Recordings
tested landing page on:
 - Galaxy Note 20 Android 11
 - iPad iPadOS 14.7.1
 - iPhone 11 Pro iOS 14.6
 - iPhone 12 Pro Max iOS 14.6
 - Alot more but it's all good to go unless the screen is really small

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: Should be alright
- [ ] I need help with writing tests