### PR TITLE
fix: Typos

### DIFF
--- a/src/pages/docs/latest/exceptions.mdx
+++ b/src/pages/docs/latest/exceptions.mdx
@@ -12,7 +12,7 @@ Don't have the thread library? [See here](./installation) for installing thread
 
 
 
-### Supressing Exceptions
+### Suppressing Exceptions
 When initializing a thread, you can parse a `suppress_errors` boolean. When a 
 exception is raised it is stored in the `Thread._errors` attribute. By default this
 is set to false.
@@ -95,7 +95,7 @@ This is the base exception class that all exceptions inherit from.
 
 This exception is raised when you attempt to invoke a method that requires the thread to not be running, but the thread is currently running.
 > You can wait for the thread to terminate with [**Thread.join()**](.thread-class#methods) before invoking the method<br />
-> You can check if the thread is running with [**Thread.is_alive()**](thread-class#methodss) before invoking the method
+> You can check if the thread is running with [**Thread.is_alive()**](thread-class#methods) before invoking the method
 
 
 
@@ -109,7 +109,7 @@ This is raised when you attempt to invoke a method which requires the thread to 
 
 ### ThreadNotInitializedError
 
-This exception is raised when you attempt to invoke a method that requires the thread to initialized, but the thread is not initalized.
+This exception is raised when you attempt to invoke a method that requires the thread to initialized, but the thread is not initialized.
 > You can initialize and start the thread with [**Thread.start()**](thread-class#methods) before invoking the method
 
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the our Code of Conduct: https://github.com/caffeine-addictt/FastAPI-ToDoApp/blob/main/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Breaking Change
- [x] Documentation Update



## Description

- Fix some typos




## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #16



## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests




## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.