### PR TITLE
Fix: Broken links

### DIFF
--- a/src/pages/docs/latest/index.mdx
+++ b/src/pages/docs/latest/index.mdx
@@ -19,11 +19,11 @@ This is the most recent stable release of `thread`.
 ## Quick Start
 
 <Cards>
-  <Card href='/docs/installation' title='Installation' icon={<LightningBoltIcon />} />
-  <Card href='/docs/configuration' title='Configuration' icon={<GearIcon />} />
-  <Card href='/docs/thread-class' title='Thread Class' icon={<MixIcon />} />
-  <Card href='/docs/parallel-processing' title='Parallel Processing Class' icon={<MixIcon />} />
-  <Card href='/docs/exceptions' title='Exceptions' icon={<ExclamationTriangleIcon />} />
-  <Card href='/docs/command-line-interface' title='Command Line Interface' icon={<CodeIcon />} />
+  <Card href='/docs/latest/installation' title='Installation' icon={<LightningBoltIcon />} />
+  <Card href='/docs/latest/configuration' title='Configuration' icon={<GearIcon />} />
+  <Card href='/docs/latest/thread-class' title='Thread Class' icon={<MixIcon />} />
+  <Card href='/docs/latest/parallel-processing' title='Parallel Processing Class' icon={<MixIcon />} />
+  <Card href='/docs/latest/exceptions' title='Exceptions' icon={<ExclamationTriangleIcon />} />
+  <Card href='/docs/latest/command-line-interface' title='Command Line Interface' icon={<CodeIcon />} />
 </Cards>
 

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -56,7 +56,7 @@ export function Feature({ title, description, version = false, href = false, ...
     <div className='py-4 flex flex-col gap-4 justify-center items-center' style={{ height: 'calc(100vh - 64px)' }}>
       <h2 className='text-5xl font-bold mb-10 text-center'>Features</h2>
       <div className='flex flex-wrap gap-8 justify-center'>
-        <Feature title='Graceful shutdown' description='Automatically kill threads before exiting the program' href='/docs/thread-class#killing-threads---introduced-in-v012' version='^v0.1.2' />
+        <Feature title='Graceful shutdown' description='Automatically kill threads before exiting the program' href='/docs/latest/configuration' version='^v0.1.2' />
         <Feature title='Parallel Processing' description='Utilize multiple threads to process large amounts of data' href='/docs/latest/parallel-processing' />
       </div>
     </div>

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -57,7 +57,7 @@ export function Feature({ title, description, version = false, href = false, ...
       <h2 className='text-5xl font-bold mb-10 text-center'>Features</h2>
       <div className='flex flex-wrap gap-8 justify-center'>
         <Feature title='Graceful shutdown' description='Automatically kill threads before exiting the program' href='/docs/thread-class#killing-threads---introduced-in-v012' version='^v0.1.2' />
-        <Feature title='Parallel Processing' description='Utilize multiple threads to process large amounts of data' href='/docs/parallel-processing' />
+        <Feature title='Parallel Processing' description='Utilize multiple threads to process large amounts of data' href='/docs/latest/parallel-processing' />
       </div>
     </div>
   </section>


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the our Code of Conduct: https://github.com/python-thread/thread.ngjx.org/blob/main/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Breaking Change
- [ ] Documentation Update



## Description

- Fix feature links on root page
- Fix card links on docs/latest

Thank you @platinops for bringing this up!



## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #44 



## QA Instructions, Screenshots, Recordings

- [x] Feature Graceful exit fixed
- [x] Feature ParallelProcessing fixed
- [x] Cards on `/docs/latest` fixed



## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests




## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.