### PR TITLE
Feat: Add verbosity setting documentation

### DIFF
--- a/src/pages/docs/latest/configuration.mdx
+++ b/src/pages/docs/latest/configuration.mdx
@@ -64,3 +64,42 @@ from thread import Settings
   </ArgumentBody>
 </ArgumentWrapper>
 
+<ArgumentWrapper>
+  <summary>
+    <strong className='text-lg'>
+      VERBOSITY
+      <ArgumentExtra>VerbosityLevel</ArgumentExtra>
+      <ArgumentExtra>(default: 'normal')</ArgumentExtra>
+    </strong>
+  </summary>
+  <ArgumentBody>
+    Adjust what is printed to the terminal.
+    <Callout type='info'>
+      This feature is only available in `thread ^v1.0.1`
+    </Callout>
+
+      Simply invoke `Setting.set_verbosity(level)` to set the verbosity level.
+      ```py
+      from thread import Settings
+
+      Settings.set_verbosity(1)
+      Settings.set_verbosity('normal')
+      ```
+
+      `Settings.VERBOSITY` can be compared against strings and integers and other `Verbosity` objects.
+      ```py
+      from thread.utils.config import Verbosity, Settings
+
+      # Mapping
+      Verbosity(0) == Verbosity('quiet')
+      Verbosity(1) == Verbosity('normal')
+      Verbosity(2) == Verbosity('verbose')
+
+      # Comparison
+      Verbosity(0) < 1          # True
+      Verbosity(1) < 'verbose'  # True
+      Verbosity(2) == 'verbose' # True
+      ```
+  </ArgumentBody>
+</ArgumentWrapper>
+


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the our Code of Conduct: https://github.com/python-thread/thread.ngjx.org/blob/main/CODE_OF_CONDUCT.md
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Breaking Change
- [x] Documentation Update



## Description

- Add documentation for verbosity



## Related Tickets & Documents
<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related https://github.com/python-thread/thread/pull/64



## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests




## Checklist
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.